### PR TITLE
Refactor query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ service:
 before_script:
   - psql -c 'drop database if exists travis_ci_test;' -U postgres
   - psql -c 'create database travis_ci_test;' -U postgres
-  - psql -h postgres -d travis_ci_test -a -f savant/app/db_scripts/tables.sql
-  - - psql -h postgres -d travis_ci_test -a -f savant/app/db_scripts/functions.sql
+  - psql -U postgres -d travis_ci_test -a -f savant/app/db_scripts/tables.sql
+  - psql -U postgres -d travis_ci_test -a -f savant/app/db_scripts/functions.sql
   - touch savant/app/db_config.json
   - cat savant/app/db_config_travis.json >> savant/app/db_config.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ service:
 before_script:
   - psql -c 'drop database if exists travis_ci_test;' -U postgres
   - psql -c 'create database travis_ci_test;' -U postgres
+  - psql -h postgres -d travis_ci_test -a -f savant/app/db_scripts/tables.sql
+  - - psql -h postgres -d travis_ci_test -a -f savant/app/db_scripts/functions.sql
   - touch savant/app/db_config.json
   - cat savant/app/db_config_travis.json >> savant/app/db_config.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ service:
 before_script:
   - psql -c 'drop database if exists travis_ci_test;' -U postgres
   - psql -c 'create database travis_ci_test;' -U postgres
-  - psql -U postgres -d travis_ci_test -a -f savant/app/db_scripts/tables.sql
-  - psql -U postgres -d travis_ci_test -a -f savant/app/db_scripts/functions.sql
+  - psql -U postgres -d travis_ci_test -a -f savant/db_scripts/tables.sql
+  - psql -U postgres -d travis_ci_test -a -f savant/db_scripts/functions.sql
   - touch savant/app/db_config.json
   - cat savant/app/db_config_travis.json >> savant/app/db_config.json
 

--- a/savant/app/base_path.py
+++ b/savant/app/base_path.py
@@ -1,4 +1,0 @@
-import os
-
-def get_path():
-    return str(os.getcwd()).split("/mono", 1)[0]

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -113,8 +113,8 @@ class Query:
         knowledge_users(new_users)
 
         self.conn.commit()
-        self.cur.close()
-        self.conn.close()
+        # self.cur.close()
+        # self.conn.close()
 
     def knowledge_debs(new_debs):
         if new_debs[0] != "No changes":

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -43,6 +43,7 @@ def execute_sql(sql_file):
 class Query:
     def __init__(self):
         # global conn, cur
+        print "Inside init"
 
         self.path = get_path() + "/mono/savant/app"
         os.chdir(self.path)
@@ -87,8 +88,8 @@ class Query:
         self.cur.executemany("select store_users(%s, %s, %s, %s,%s, %s, %s)", get_scanned.users)    
 
         self.conn.commit()
-        self.cur.close()
-        self.conn.close()
+        # self.cur.close()
+        # self.conn.close()
 
     def record_knowledge(self, json_file, name, resource, action):
         # set_engine_name()
@@ -98,50 +99,55 @@ class Query:
         with open(json_file, 'r') as json_res:
             self.res =  json.load(json_res)
 
-        debs = res[0]
+        debs = self.res[0]
         new_debs = debs["Debs"]["New"]
-        groups = res[1]
+        groups = self.res[1]
         new_groups = groups["Groups"]["New"]
-        shadow = res[2]
+        shadow = self.res[2]
         new_shadow = shadow["Shadow"]["New"]
-        users = res[3]
+        users = self.res[3]
         new_users = users["Users"]["New"]
 
-        knowledge_debs(new_debs)
-        knowledge_groups(new_groups)
-        knowledge_shadow(new_shadow)
-        knowledge_users(new_users)
+        self.knowledge_debs(new_debs)
+        self.knowledge_groups(new_groups)
+        self.knowledge_shadow(new_shadow)
+        self.knowledge_users(new_users)
 
         self.conn.commit()
         # self.cur.close()
         # self.conn.close()
 
-    def knowledge_debs(new_debs):
-        if new_debs[0] != "No changes":
-            for nd in new_debs:
-                deb = cur.execute("select store_knowledge_debs(%s, %s ,%s, %s)", (nd["Stat"], nd["Name"], nd["Version"], nd["Architecture"]))
+    def knowledge_debs(self, new_debs):
+        if self.new_debs[0] != "No changes":
+            for self.nd in self.new_debs:
+                self.deb = self.cur.execute("select store_knowledge_debs(%s, %s ,%s, %s)",
+                                                                                     (self.nd["Stat"], self.nd["Name"],
+                                                                                        self.nd["Version"], self.nd["Architecture"]))
 
-    def knowledge_groups(new_groups):
-        if new_groups[0] != "No changes":
-            for ng in new_groups:
-                cur.execute("select store_knowledge_groups(%s, %s ,%s, %s)", (ng["Group Name"], ng["Password"], ng["Gid"], ng["Users"]))
+    def knowledge_groups(self, new_groups):
+        if self.new_groups[0] != "No changes":
+            for self.ng in self.new_groups:
+                self.cur.execute("select store_knowledge_groups(%s, %s ,%s, %s)",
+                                                                        (self.ng["Group Name"], self.ng["Password"],
+                                                                         self.ng["Gid"], self.ng["Users"]))
 
-    def knowledge_shadow(new_shadow):
-        if new_shadow[0] != "No changes":
+    def knowledge_shadow(self, new_shadow):
+        if self.new_shadow[0] != "No changes":
+            for self.ns in self.new_shadow:
+                self.cur.execute("select store_knowledge_shadow(%s, %s ,%s, %s, %s, %s ,%s, %s, %s)",
+                                                                                            (self.ns["Username"], self.ns["Password"],
+                                                                                            self.ns["Last Changed"],
+                                                                                            self.ns["Minimum"], self.ns["Maximum"],
+                                                                                            self.ns["Warn"], self.ns["Inactive"],
+                                                                                            self.ns["Expire"], self.ns["Reserve"]))
 
-            for ns in new_shadow:
-                cur.execute("select store_knowledge_shadow(%s, %s ,%s, %s, %s, %s ,%s, %s, %s)", (ns["Username"], ns["Password"],
-                                                                                            ns["Last Changed"], ns["Minimum"],
-                                                                                            ns["Maximum"],
-                                                                                            ns["Warn"], ns["Inactive"],
-                                                                                            ns["Expire"], ns["Reserve"]))
-
-    def knowledge_users(new_users):
-        if new_users[0] != "No changes":
-            for nu in new_users:
-                cur.execute("select store_knowledge_users(%s, %s ,%s, %s, %s, %s, %s )", (nu["Username"], nu["Password"],
-                                                                                    nu["UID"], nu["GID"],
-                                                                                    nu["Description"], nu["Path"], nu["Shell"]))
+    def knowledge_users(self, new_users):
+        if self.new_users[0] != "No changes":
+            for self.nu in self.new_users:
+                self.cur.execute("select store_knowledge_users(%s, %s ,%s, %s, %s, %s, %s )",
+                                                                                (self.nu["Username"], self.nu["Password"],
+                                                                                self.nu["UID"], self.nu["GID"],
+                                                                                self.nu["Description"], self.nu["Path"], self.nu["Shell"]))
     def new_debs(self):
         # set_engine_name()
 
@@ -150,8 +156,8 @@ class Query:
         self.new_debs = []
 
         if len(self.debs) != 0:
-            for self.deb in debs:
-                d = str(deb[0])
+            for self.deb in self.debs:
+                d = str(self.deb[0])
                 db = d.split(',')
                 self.new_debs.append({"Stat" : db[0][1:],
                             "Name" : db[1],
@@ -161,47 +167,47 @@ class Query:
             self.new_debs.append('No changes')
 
         self.conn.commit()
-        self.cur.close()
-        self.conn.close()
+        # self.cur.close()
+        # self.conn.close()
 
         return self.new_debs
 
-    def new_groups():
+    def new_groups(self):
         # set_engine_name()
 
-        groups = cur.execute("select get_groups_unique()")
-        groups = cur.fetchall()
-        new_groups = []
+        self.groups = self.cur.execute("select get_groups_unique()")
+        self.groups = self.cur.fetchall()
+        self.new_groups = []
 
-        if len(groups) != 0:
-            for group in groups:
-                g = str(group[0])
+        if len(self.groups) != 0:
+            for self.group in self.groups:
+                g = str(self.group[0])
                 gr = g.split(',')
-                new_groups.append({"Group Name" : gr[0][1:],
+                self.new_groups.append({"Group Name" : gr[0][1:],
                                 "Password" : gr[1],
                                 "Gid" : gr[2],
                                 "Users" : gr[3][:len(gr[3]) - 1]})
         else:
-            new_groups.append('No changes')
+            self.new_groups.append('No changes')
 
-        conn.commit()
-        cur.close()
-        conn.close()
+        self.conn.commit()
+        # cur.close()
+        # conn.close()
 
-        return new_groups
+        return self.new_groups
 
-    def new_shadow():
+    def new_shadow(self):
         # set_engine_name()
 
-        shadow = cur.execute("select get_shadow_unique()")
-        shadow = cur.fetchall()
-        new_shadow = []
+        self.shadow = self.cur.execute("select get_shadow_unique()")
+        self.shadow = self.cur.fetchall()
+        self.new_shadow = []
 
-        if len(shadow) != 0:
-            for shad in shadow:
-                s = str(shad[0])
+        if len(self.shadow) != 0:
+            for self.shad in self.shadow:
+                s = str(self.shad[0])
                 sh = s.split(',')
-                new_shadow.append({"Username" : sh[0][1:],
+                self.new_shadow.append({"Username" : sh[0][1:],
                                 "Password" : sh[1],
                                 "Last Changed" : sh[2],
                                 "Minimum" : sh[3],
@@ -211,26 +217,26 @@ class Query:
                                 "Expire" : sh[7],
                                 "Reserve" : sh[8][:len(sh[8]) - 1]})
         else:
-            new_shadow.append('No changes')
+            self.new_shadow.append('No changes')
 
-        conn.commit()
-        cur.close()
-        conn.close()
+        self.conn.commit()
+        # cur.close()
+        # conn.close()
         
-        return new_shadow
+        return self.new_shadow
 
-    def new_users():
+    def new_users(self):
         # set_engine_name()
 
-        users = cur.execute("select get_users_unique()")
-        users = cur.fetchall()
-        new_users = []
+        self.users = self.cur.execute("select get_users_unique()")
+        self.users = self.cur.fetchall()
+        self.new_users = []
 
-        if len(users) != 0:
-            for user in users:
-                u = str(user[0])
+        if len(self.users) != 0:
+            for self.user in self.users:
+                u = str(self.user[0])
                 us = u.split(',')
-                new_users.append({"Username" : us[0][1:],
+                self.new_users.append({"Username" : us[0][1:],
                                 "Password" : us[1],
                                 "UID" : us[2],
                                 "GID" : us[3],
@@ -239,10 +245,10 @@ class Query:
                                 "Shell" : us[6][:len(us[6]) - 1]})
 
         else:
-            new_users.append('No changes')
+            self.new_users.append('No changes')
 
-        conn.commit()
-        cur.close()
-        conn.close()
+        self.conn.commit()
+        # cur.close()
+        # conn.close()
 
-        return new_users
+        return self.new_users

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -35,9 +35,7 @@ class Query:
         self.conn.commit()
 
     def record_knowledge(self, json_file, name, resource, action):
-
         self.cur.execute("select store_knowledge(%s, %s, %s)", (name, resource, action))
-
         with open(json_file, 'r') as json_res:
             self.res =  json.load(json_res)
 
@@ -52,31 +50,19 @@ class Query:
 
         if new_debs[0] != "No changes":
             for self.nd in new_debs:
-                self.deb = self.cur.execute("select store_knowledge_debs(%s, %s ,%s, %s)",
-                                                                                     (self.nd["Stat"], self.nd["Name"],
-                                                                                        self.nd["Version"], self.nd["Architecture"]))
+                self.deb = self.cur.execute("select store_knowledge_debs(%s, %s ,%s, %s)", (self.nd["Stat"], self.nd["Name"], self.nd["Version"], self.nd["Architecture"]))
 
         if new_groups[0] != "No changes":
             for self.ng in new_groups:
-                self.cur.execute("select store_knowledge_groups(%s, %s ,%s, %s)",
-                                                                        (self.ng["Group Name"], self.ng["Password"],
-                                                                         self.ng["Gid"], self.ng["Users"]))
+                self.cur.execute("select store_knowledge_groups(%s, %s ,%s, %s)", (self.ng["Group Name"], self.ng["Password"], self.ng["Gid"], self.ng["Users"]))
 
         if new_shadow[0] != "No changes":
             for self.ns in new_shadow:
-                self.cur.execute("select store_knowledge_shadow(%s, %s ,%s, %s, %s, %s ,%s, %s, %s)",
-                                                                                            (self.ns["Username"], self.ns["Password"],
-                                                                                            self.ns["Last Changed"],
-                                                                                            self.ns["Minimum"], self.ns["Maximum"],
-                                                                                            self.ns["Warn"], self.ns["Inactive"],
-                                                                                            self.ns["Expire"], self.ns["Reserve"]))
+                self.cur.execute("select store_knowledge_shadow(%s, %s ,%s, %s, %s, %s ,%s, %s, %s)", (self.ns["Username"], self.ns["Password"], self.ns["Last Changed"], self.ns["Minimum"], self.ns["Maximum"], self.ns["Warn"], self.ns["Inactive"], self.ns["Expire"], self.ns["Reserve"]))
 
         if new_users[0] != "No changes":
             for self.nu in new_users:
-                self.cur.execute("select store_knowledge_users(%s, %s ,%s, %s, %s, %s, %s )",
-                                                                                (self.nu["Username"], self.nu["Password"],
-                                                                                self.nu["UID"], self.nu["GID"],
-                                                                                self.nu["Description"], self.nu["Path"], self.nu["Shell"]))
+                self.cur.execute("select store_knowledge_users(%s, %s ,%s, %s, %s, %s, %s )",(self.nu["Username"], self.nu["Password"], self.nu["UID"], self.nu["GID"], self.nu["Description"], self.nu["Path"], self.nu["Shell"]))
         self.conn.commit()
 
     def new_debs(self):

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -6,12 +6,12 @@ from sqlalchemy import create_engine
 from app import app
 from app import get_scanned
 
+path = str(os.getcwd()).split("/mono", 1)[0]
+
 class Query:
     def __init__(self):
 
-        print "dir jos: ", os.getcwd()
-
-        with open('app/db_config.json', 'r') as db_file:
+        with open(path + '/mono/savant/app/db_config.json', 'r') as db_file:
             db_info = json.load(db_file)
 
         self.db_name = db_info["database"]["database_name"]

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -89,8 +89,8 @@ class Query:
         self.cur.executemany("select store_users(%s, %s, %s, %s,%s, %s, %s)", get_scanned.users)    
 
         self.conn.commit()
-        self.cur.close()
-        self.conn.close()
+        # self.cur.close()
+        # self.conn.close()
 
     def record_knowledge(self, json_file, name, resource, action):
         # set_engine_name()

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -7,43 +7,8 @@ from app import app
 from app.base_path import get_path
 from app import get_scanned
 
-# def set_engine_name():
-#     global conn, cur
-
-#     path = get_path() + "/mono/savant/app"
-#     os.chdir(path)
-
-#     with open('db_config.json', 'r') as db_file:
-#         db_info = json.load(db_file)
-
-#     db_name = db_info["database"]["database_name"]
-#     username = db_info["database"]["username"]
-#     password = db_info["database"]["password"]
-#     host = db_info["database"]["host"]
-#     engine_name = "postgresql://" + username + ":" + password + "@" + host + ":5432/" + db_name
-
-#     conn = psycopg2.connect(engine_name)
-#     cur = conn.cursor()
-
-def execute_sql(sql_file):
-    set_engine_name()
-
-    path = get_path()
-    if not path.__contains__("/mono/savant/db_script"):
-        db_directory = path + "/mono/savant/db_scripts"
-    else:
-        db_directory = path
-
-    os.chdir(db_directory)
-    cur.execute(open(str(sql_file), "r").read())
-    conn.commit()
-    cur.close()
-    conn.close()
-
 class Query:
     def __init__(self):
-        # global conn, cur
-        print "Inside init"
 
         self.path = get_path() + "/mono/savant/app"
         os.chdir(self.path)
@@ -58,42 +23,18 @@ class Query:
         self.engine_name = "postgresql://" + self.username + ":" + self.password + "@" + self.host + ":5432/" + self.db_name
 
         self.conn = psycopg2.connect(self.engine_name)
-        print "Cursor is closed: ", self.conn.cursor().closed
         self.cur = self.conn.cursor()
 
-    # def set_engine_name(self):
-    #     global conn, cur
-
-    #     path = get_path() + "/mono/savant/app"
-    #     os.chdir(path)
-
-    #     with open('db_config.json', 'r') as db_file:
-    #         db_info = json.load(db_file)
-
-    #     db_name = db_info["database"]["database_name"]
-    #     username = db_info["database"]["username"]
-    #     password = db_info["database"]["password"]
-    #     host = db_info["database"]["host"]
-    #     engine_name = "postgresql://" + username + ":" + password + "@" + host + ":5432/" + db_name
-
-    #     conn = psycopg2.connect(engine_name)
-    #     cur = conn.cursor()
-
     def record_flavors(self):
-        # set_engine_name()
 
         self.cur.execute("select store_datetime()")
         self.cur.executemany("select store_debs(%s, %s ,%s, %s)", get_scanned.debs)
         self.cur.executemany("select store_groups(%s, %s, %s, %s)", get_scanned.groups)
         self.cur.executemany("select store_shadow(%s, %s, %s, %s, %s, %s, %s, %s, %s)", get_scanned.shadow)
-        self.cur.executemany("select store_users(%s, %s, %s, %s,%s, %s, %s)", get_scanned.users)    
-
+        self.cur.executemany("select store_users(%s, %s, %s, %s,%s, %s, %s)", get_scanned.users)
         self.conn.commit()
-        # self.cur.close()
-        # self.conn.close()
 
     def record_knowledge(self, json_file, name, resource, action):
-        # set_engine_name()
 
         self.cur.execute("select store_knowledge(%s, %s, %s)", (name, resource, action))
 
@@ -113,10 +54,7 @@ class Query:
         self.knowledge_groups(new_groups)
         self.knowledge_shadow(new_shadow)
         self.knowledge_users(new_users)
-
         self.conn.commit()
-        # self.cur.close()
-        # self.conn.close()
 
     def knowledge_debs(self, new_debs):
         if new_debs[0] != "No changes":
@@ -150,7 +88,6 @@ class Query:
                                                                                 self.nu["UID"], self.nu["GID"],
                                                                                 self.nu["Description"], self.nu["Path"], self.nu["Shell"]))
     def new_debs(self):
-        # set_engine_name()
 
         self.debs = self.cur.execute("select get_debs_unique()")
         self.debs = self.cur.fetchall()
@@ -168,13 +105,10 @@ class Query:
             self.new_debs.append('No changes')
 
         self.conn.commit()
-        # self.cur.close()
-        # self.conn.close()
 
         return self.new_debs
 
     def new_groups(self):
-        # set_engine_name()
 
         self.groups = self.cur.execute("select get_groups_unique()")
         self.groups = self.cur.fetchall()
@@ -192,13 +126,10 @@ class Query:
             self.new_groups.append('No changes')
 
         self.conn.commit()
-        # cur.close()
-        # conn.close()
 
         return self.new_groups
 
     def new_shadow(self):
-        # set_engine_name()
 
         self.shadow = self.cur.execute("select get_shadow_unique()")
         self.shadow = self.cur.fetchall()
@@ -221,8 +152,6 @@ class Query:
             self.new_shadow.append('No changes')
 
         self.conn.commit()
-        # cur.close()
-        # conn.close()
         
         return self.new_shadow
 
@@ -249,7 +178,17 @@ class Query:
             self.new_users.append('No changes')
 
         self.conn.commit()
-        # cur.close()
-        # conn.close()
-
+        
         return self.new_users
+
+    def execute_sql(self, sql_file):
+
+        self.path = get_path()
+        if not self.path.__contains__("/mono/savant/db_script"):
+            self.db_directory = self.path + "/mono/savant/db_scripts"
+        else:
+            self.db_directory = self.path
+
+        os.chdir(self.db_directory)
+        self.cur.execute(open(str(sql_file), "r").read())
+        self.conn.commit()

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -156,7 +156,6 @@ class Query:
         return self.new_shadow
 
     def new_users(self):
-        # set_engine_name()
 
         self.users = self.cur.execute("select get_users_unique()")
         self.users = self.cur.fetchall()

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -7,23 +7,23 @@ from app import app
 from app.base_path import get_path
 from app import get_scanned
 
-def set_engine_name():
-    global conn, cur
+# def set_engine_name():
+#     global conn, cur
 
-    path = get_path() + "/mono/savant/app"
-    os.chdir(path)
+#     path = get_path() + "/mono/savant/app"
+#     os.chdir(path)
 
-    with open('db_config.json', 'r') as db_file:
-        db_info = json.load(db_file)
+#     with open('db_config.json', 'r') as db_file:
+#         db_info = json.load(db_file)
 
-    db_name = db_info["database"]["database_name"]
-    username = db_info["database"]["username"]
-    password = db_info["database"]["password"]
-    host = db_info["database"]["host"]
-    engine_name = "postgresql://" + username + ":" + password + "@" + host + ":5432/" + db_name
+#     db_name = db_info["database"]["database_name"]
+#     username = db_info["database"]["username"]
+#     password = db_info["database"]["password"]
+#     host = db_info["database"]["host"]
+#     engine_name = "postgresql://" + username + ":" + password + "@" + host + ":5432/" + db_name
 
-    conn = psycopg2.connect(engine_name)
-    cur = conn.cursor()
+#     conn = psycopg2.connect(engine_name)
+#     cur = conn.cursor()
 
 def execute_sql(sql_file):
     set_engine_name()
@@ -40,132 +40,168 @@ def execute_sql(sql_file):
     cur.close()
     conn.close()
 
-def record_flavors():
-    set_engine_name()
+class Query:
+    def __init__(self):
+        # global conn, cur
 
-    cur.execute("select store_datetime()")
-    cur.executemany("select store_debs(%s, %s ,%s, %s)", get_scanned.debs)
-    cur.executemany("select store_groups(%s, %s, %s, %s)", get_scanned.groups)
-    cur.executemany("select store_shadow(%s, %s, %s, %s, %s, %s, %s, %s, %s)", get_scanned.shadow)
-    cur.executemany("select store_users(%s, %s, %s, %s,%s, %s, %s)", get_scanned.users)    
+        self.path = get_path() + "/mono/savant/app"
+        os.chdir(self.path)
 
-    conn.commit()
-    cur.close()
-    conn.close()
+        with open('db_config.json', 'r') as db_file:
+            db_info = json.load(db_file)
 
-def record_knowledge(json_file, name, resource, action):
-    set_engine_name()
+        self.db_name = db_info["database"]["database_name"]
+        self.username = db_info["database"]["username"]
+        self.password = db_info["database"]["password"]
+        self.host = db_info["database"]["host"]
+        self.engine_name = "postgresql://" + self.username + ":" + self.password + "@" + self.host + ":5432/" + self.db_name
 
-    cur.execute("select store_knowledge(%s, %s, %s)", (name, resource, action))
+        self.conn = psycopg2.connect(self.engine_name)
+        self.cur = self.conn.cursor()
 
-    with open(json_file, 'r') as json_res:
-        res =  json.load(json_res)
+    # def set_engine_name(self):
+    #     global conn, cur
 
-    debs = res[0]
-    new_debs = debs["Debs"]["New"]
-    groups = res[1]
-    new_groups = groups["Groups"]["New"]
-    shadow = res[2]
-    new_shadow = shadow["Shadow"]["New"]
-    users = res[3]
-    new_users = users["Users"]["New"]
+    #     path = get_path() + "/mono/savant/app"
+    #     os.chdir(path)
 
-    knowledge_debs(new_debs)
-    knowledge_groups(new_groups)
-    knowledge_shadow(new_shadow)
-    knowledge_users(new_users)
+    #     with open('db_config.json', 'r') as db_file:
+    #         db_info = json.load(db_file)
 
-    conn.commit()
-    cur.close()
-    conn.close()
+    #     db_name = db_info["database"]["database_name"]
+    #     username = db_info["database"]["username"]
+    #     password = db_info["database"]["password"]
+    #     host = db_info["database"]["host"]
+    #     engine_name = "postgresql://" + username + ":" + password + "@" + host + ":5432/" + db_name
 
-def knowledge_debs(new_debs):
-    if new_debs[0] != "No changes":
-        for nd in new_debs:
-            deb = cur.execute("select store_knowledge_debs(%s, %s ,%s, %s)", (nd["Stat"], nd["Name"], nd["Version"], nd["Architecture"]))
+    #     conn = psycopg2.connect(engine_name)
+    #     cur = conn.cursor()
 
-def knowledge_groups(new_groups):
-    if new_groups[0] != "No changes":
-        for ng in new_groups:
-            cur.execute("select store_knowledge_groups(%s, %s ,%s, %s)", (ng["Group Name"], ng["Password"], ng["Gid"], ng["Users"]))
+    def record_flavors(self):
+        # set_engine_name()
 
-def knowledge_shadow(new_shadow):
-    if new_shadow[0] != "No changes":
+        self.cur.execute("select store_datetime()")
+        self.cur.executemany("select store_debs(%s, %s ,%s, %s)", get_scanned.debs)
+        self.cur.executemany("select store_groups(%s, %s, %s, %s)", get_scanned.groups)
+        self.cur.executemany("select store_shadow(%s, %s, %s, %s, %s, %s, %s, %s, %s)", get_scanned.shadow)
+        self.cur.executemany("select store_users(%s, %s, %s, %s,%s, %s, %s)", get_scanned.users)    
 
-        for ns in new_shadow:
-            cur.execute("select store_knowledge_shadow(%s, %s ,%s, %s, %s, %s ,%s, %s, %s)", (ns["Username"], ns["Password"],
+        self.conn.commit()
+        self.cur.close()
+        self.conn.close()
+
+    def record_knowledge(self, json_file, name, resource, action):
+        # set_engine_name()
+
+        self.cur.execute("select store_knowledge(%s, %s, %s)", (name, resource, action))
+
+        with open(json_file, 'r') as json_res:
+            self.res =  json.load(json_res)
+
+        debs = res[0]
+        new_debs = debs["Debs"]["New"]
+        groups = res[1]
+        new_groups = groups["Groups"]["New"]
+        shadow = res[2]
+        new_shadow = shadow["Shadow"]["New"]
+        users = res[3]
+        new_users = users["Users"]["New"]
+
+        knowledge_debs(new_debs)
+        knowledge_groups(new_groups)
+        knowledge_shadow(new_shadow)
+        knowledge_users(new_users)
+
+        self.conn.commit()
+        self.cur.close()
+        self.conn.close()
+
+    def knowledge_debs(new_debs):
+        if new_debs[0] != "No changes":
+            for nd in new_debs:
+                deb = cur.execute("select store_knowledge_debs(%s, %s ,%s, %s)", (nd["Stat"], nd["Name"], nd["Version"], nd["Architecture"]))
+
+    def knowledge_groups(new_groups):
+        if new_groups[0] != "No changes":
+            for ng in new_groups:
+                cur.execute("select store_knowledge_groups(%s, %s ,%s, %s)", (ng["Group Name"], ng["Password"], ng["Gid"], ng["Users"]))
+
+    def knowledge_shadow(new_shadow):
+        if new_shadow[0] != "No changes":
+
+            for ns in new_shadow:
+                cur.execute("select store_knowledge_shadow(%s, %s ,%s, %s, %s, %s ,%s, %s, %s)", (ns["Username"], ns["Password"],
                                                                                             ns["Last Changed"], ns["Minimum"],
                                                                                             ns["Maximum"],
                                                                                             ns["Warn"], ns["Inactive"],
                                                                                             ns["Expire"], ns["Reserve"]))
 
-def knowledge_users(new_users):
-    if new_users[0] != "No changes":
-        for nu in new_users:
-            cur.execute("select store_knowledge_users(%s, %s ,%s, %s, %s, %s, %s )", (nu["Username"], nu["Password"],
+    def knowledge_users(new_users):
+        if new_users[0] != "No changes":
+            for nu in new_users:
+                cur.execute("select store_knowledge_users(%s, %s ,%s, %s, %s, %s, %s )", (nu["Username"], nu["Password"],
                                                                                     nu["UID"], nu["GID"],
                                                                                     nu["Description"], nu["Path"], nu["Shell"]))
+    def new_debs(self):
+        # set_engine_name()
 
-def new_debs():
-    set_engine_name()
+        self.debs = self.cur.execute("select get_debs_unique()")
+        self.debs = self.cur.fetchall()
+        self.new_debs = []
 
-    debs = cur.execute("select get_debs_unique()")
-    debs = cur.fetchall()
-    new_debs = []
-
-    if len(debs) != 0:
-        for deb in debs:
-            d = str(deb[0])
-            db = d.split(',')
-            new_debs.append({"Stat" : db[0][1:],
+        if len(self.debs) != 0:
+            for self.deb in debs:
+                d = str(deb[0])
+                db = d.split(',')
+                self.new_debs.append({"Stat" : db[0][1:],
                             "Name" : db[1],
                             "Version" : db[2],
                             "Architecture" : db[3][:len(db[3]) - 1]})
-    else:
-        new_debs.append('No changes')
+        else:
+            self.new_debs.append('No changes')
 
-    conn.commit()
-    cur.close()
-    conn.close()
+        self.conn.commit()
+        self.cur.close()
+        self.conn.close()
 
-    return new_debs
+        return self.new_debs
 
-def new_groups():
-    set_engine_name()
+    def new_groups():
+        # set_engine_name()
 
-    groups = cur.execute("select get_groups_unique()")
-    groups = cur.fetchall()
-    new_groups = []
+        groups = cur.execute("select get_groups_unique()")
+        groups = cur.fetchall()
+        new_groups = []
 
-    if len(groups) != 0:
-        for group in groups:
-            g = str(group[0])
-            gr = g.split(',')
-            new_groups.append({"Group Name" : gr[0][1:],
+        if len(groups) != 0:
+            for group in groups:
+                g = str(group[0])
+                gr = g.split(',')
+                new_groups.append({"Group Name" : gr[0][1:],
                                 "Password" : gr[1],
                                 "Gid" : gr[2],
                                 "Users" : gr[3][:len(gr[3]) - 1]})
-    else:
-        new_groups.append('No changes')
+        else:
+            new_groups.append('No changes')
 
-    conn.commit()
-    cur.close()
-    conn.close()
+        conn.commit()
+        cur.close()
+        conn.close()
 
-    return new_groups
+        return new_groups
 
-def new_shadow():
-    set_engine_name()
+    def new_shadow():
+        # set_engine_name()
 
-    shadow = cur.execute("select get_shadow_unique()")
-    shadow = cur.fetchall()
-    new_shadow = []
+        shadow = cur.execute("select get_shadow_unique()")
+        shadow = cur.fetchall()
+        new_shadow = []
 
-    if len(shadow) != 0:
-        for shad in shadow:
-            s = str(shad[0])
-            sh = s.split(',')
-            new_shadow.append({"Username" : sh[0][1:],
+        if len(shadow) != 0:
+            for shad in shadow:
+                s = str(shad[0])
+                sh = s.split(',')
+                new_shadow.append({"Username" : sh[0][1:],
                                 "Password" : sh[1],
                                 "Last Changed" : sh[2],
                                 "Minimum" : sh[3],
@@ -174,27 +210,27 @@ def new_shadow():
                                 "Inactive" : sh[6],
                                 "Expire" : sh[7],
                                 "Reserve" : sh[8][:len(sh[8]) - 1]})
-    else:
-        new_shadow.append('No changes')
+        else:
+            new_shadow.append('No changes')
 
-    conn.commit()
-    cur.close()
-    conn.close()
+        conn.commit()
+        cur.close()
+        conn.close()
         
-    return new_shadow
+        return new_shadow
 
-def new_users():
-    set_engine_name()
+    def new_users():
+        # set_engine_name()
 
-    users = cur.execute("select get_users_unique()")
-    users = cur.fetchall()
-    new_users = []
+        users = cur.execute("select get_users_unique()")
+        users = cur.fetchall()
+        new_users = []
 
-    if len(users) != 0:
-        for user in users:
-            u = str(user[0])
-            us = u.split(',')
-            new_users.append({"Username" : us[0][1:],
+        if len(users) != 0:
+            for user in users:
+                u = str(user[0])
+                us = u.split(',')
+                new_users.append({"Username" : us[0][1:],
                                 "Password" : us[1],
                                 "UID" : us[2],
                                 "GID" : us[3],
@@ -202,11 +238,11 @@ def new_users():
                                 "Path" : us[5],
                                 "Shell" : us[6][:len(us[6]) - 1]})
 
-    else:
-        new_users.append('No changes')
+        else:
+            new_users.append('No changes')
 
-    conn.commit()
-    cur.close()
-    conn.close()
+        conn.commit()
+        cur.close()
+        conn.close()
 
-    return new_users
+        return new_users

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -58,6 +58,7 @@ class Query:
         self.engine_name = "postgresql://" + self.username + ":" + self.password + "@" + self.host + ":5432/" + self.db_name
 
         self.conn = psycopg2.connect(self.engine_name)
+        print "Cursor is closed: ", self.conn.cursor().closed
         self.cur = self.conn.cursor()
 
     # def set_engine_name(self):
@@ -118,22 +119,22 @@ class Query:
         # self.conn.close()
 
     def knowledge_debs(self, new_debs):
-        if self.new_debs[0] != "No changes":
-            for self.nd in self.new_debs:
+        if new_debs[0] != "No changes":
+            for self.nd in new_debs:
                 self.deb = self.cur.execute("select store_knowledge_debs(%s, %s ,%s, %s)",
                                                                                      (self.nd["Stat"], self.nd["Name"],
                                                                                         self.nd["Version"], self.nd["Architecture"]))
 
     def knowledge_groups(self, new_groups):
-        if self.new_groups[0] != "No changes":
-            for self.ng in self.new_groups:
+        if new_groups[0] != "No changes":
+            for self.ng in new_groups:
                 self.cur.execute("select store_knowledge_groups(%s, %s ,%s, %s)",
                                                                         (self.ng["Group Name"], self.ng["Password"],
                                                                          self.ng["Gid"], self.ng["Users"]))
 
     def knowledge_shadow(self, new_shadow):
-        if self.new_shadow[0] != "No changes":
-            for self.ns in self.new_shadow:
+        if new_shadow[0] != "No changes":
+            for self.ns in new_shadow:
                 self.cur.execute("select store_knowledge_shadow(%s, %s ,%s, %s, %s, %s ,%s, %s, %s)",
                                                                                             (self.ns["Username"], self.ns["Password"],
                                                                                             self.ns["Last Changed"],
@@ -142,8 +143,8 @@ class Query:
                                                                                             self.ns["Expire"], self.ns["Reserve"]))
 
     def knowledge_users(self, new_users):
-        if self.new_users[0] != "No changes":
-            for self.nu in self.new_users:
+        if new_users[0] != "No changes":
+            for self.nu in new_users:
                 self.cur.execute("select store_knowledge_users(%s, %s ,%s, %s, %s, %s, %s )",
                                                                                 (self.nu["Username"], self.nu["Password"],
                                                                                 self.nu["UID"], self.nu["GID"],

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -4,7 +4,6 @@ import os
 import psycopg2
 from sqlalchemy import create_engine
 from app import app
-from app.base_path import get_path
 from app import get_scanned
 
 class Query:

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -9,6 +9,8 @@ from app import get_scanned
 class Query:
     def __init__(self):
 
+        print "dir: ", os.getcwd()
+
         with open('app/db_config.json', 'r') as db_file:
             db_info = json.load(db_file)
 

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -52,7 +52,6 @@ class Query:
 
         if new_debs[0] != "No changes":
             for self.nd in new_debs:
-                print "nd: ", self.nd
                 self.deb = self.cur.execute("select store_knowledge_debs(%s, %s ,%s, %s)",
                                                                                      (self.nd["Stat"], self.nd["Name"],
                                                                                         self.nd["Version"], self.nd["Architecture"]))

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -9,7 +9,7 @@ from app import get_scanned
 class Query:
     def __init__(self):
 
-        print "dir: ", os.getcwd()
+        print "dir jos: ", os.getcwd()
 
         with open('app/db_config.json', 'r') as db_file:
             db_info = json.load(db_file)

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -89,8 +89,8 @@ class Query:
         self.cur.executemany("select store_users(%s, %s, %s, %s,%s, %s, %s)", get_scanned.users)    
 
         self.conn.commit()
-        # self.cur.close()
-        # self.conn.close()
+        self.cur.close()
+        self.conn.close()
 
     def record_knowledge(self, json_file, name, resource, action):
         # set_engine_name()

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -9,10 +9,7 @@ from app import get_scanned
 class Query:
     def __init__(self):
 
-        self.path = get_path() + "/mono/savant/app"
-        os.chdir(self.path)
-
-        with open('db_config.json', 'r') as db_file:
+        with open('app/db_config.json', 'r') as db_file:
             db_info = json.load(db_file)
 
         self.db_name = db_info["database"]["database_name"]
@@ -35,7 +32,7 @@ class Query:
 
     def record_knowledge(self, json_file, name, resource, action):
         self.cur.execute("select store_knowledge(%s, %s, %s)", (name, resource, action))
-        with open(json_file, 'r') as json_res:
+        with open("app/" + json_file, 'r') as json_res:
             self.res =  json.load(json_res)
 
         debs = self.res[0]

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -157,15 +157,3 @@ class Query:
         self.conn.commit()
         
         return self.new_users
-
-    def execute_sql(self, sql_file):
-
-        self.path = get_path()
-        if not self.path.__contains__("/mono/savant/db_script"):
-            self.db_directory = self.path + "/mono/savant/db_scripts"
-        else:
-            self.db_directory = self.path
-
-        os.chdir(self.db_directory)
-        self.cur.execute(open(str(sql_file), "r").read())
-        self.conn.commit()

--- a/savant/app/query.py
+++ b/savant/app/query.py
@@ -50,27 +50,19 @@ class Query:
         users = self.res[3]
         new_users = users["Users"]["New"]
 
-        self.knowledge_debs(new_debs)
-        self.knowledge_groups(new_groups)
-        self.knowledge_shadow(new_shadow)
-        self.knowledge_users(new_users)
-        self.conn.commit()
-
-    def knowledge_debs(self, new_debs):
         if new_debs[0] != "No changes":
             for self.nd in new_debs:
+                print "nd: ", self.nd
                 self.deb = self.cur.execute("select store_knowledge_debs(%s, %s ,%s, %s)",
                                                                                      (self.nd["Stat"], self.nd["Name"],
                                                                                         self.nd["Version"], self.nd["Architecture"]))
 
-    def knowledge_groups(self, new_groups):
         if new_groups[0] != "No changes":
             for self.ng in new_groups:
                 self.cur.execute("select store_knowledge_groups(%s, %s ,%s, %s)",
                                                                         (self.ng["Group Name"], self.ng["Password"],
                                                                          self.ng["Gid"], self.ng["Users"]))
 
-    def knowledge_shadow(self, new_shadow):
         if new_shadow[0] != "No changes":
             for self.ns in new_shadow:
                 self.cur.execute("select store_knowledge_shadow(%s, %s ,%s, %s, %s, %s ,%s, %s, %s)",
@@ -80,13 +72,14 @@ class Query:
                                                                                             self.ns["Warn"], self.ns["Inactive"],
                                                                                             self.ns["Expire"], self.ns["Reserve"]))
 
-    def knowledge_users(self, new_users):
         if new_users[0] != "No changes":
             for self.nu in new_users:
                 self.cur.execute("select store_knowledge_users(%s, %s ,%s, %s, %s, %s, %s )",
                                                                                 (self.nu["Username"], self.nu["Password"],
                                                                                 self.nu["UID"], self.nu["GID"],
                                                                                 self.nu["Description"], self.nu["Path"], self.nu["Shell"]))
+        self.conn.commit()
+
     def new_debs(self):
 
         self.debs = self.cur.execute("select get_debs_unique()")

--- a/savant/app/results.py
+++ b/savant/app/results.py
@@ -13,8 +13,8 @@ def create_flavors():
     filenames = request.files.getlist('files[]')
     get_scanned.get_items(filenames)
     # query.record_flavors()
-    que = query.Query()
-    que.record_flavors()
+    que_flavors = query.Query()
+    que_flavors.record_flavors()
 
     return jsonify({"Status" : "OK", "Message" : "Saved"})
 
@@ -23,15 +23,15 @@ def compare():
     filenames = request.files.getlist('files[]')
 
     get_scanned.get_items(filenames)
-    que = query.Query()
-    que.record_flavors()
+    que_records = query.Query()
+    que_records.record_flavors()
 
     json_file = "Comparison-" + now.strftime("%Y-%m-%d_%H:%M") + ".json"
 
-    new_packages =  json.dumps([{"Debs" : {"New" : que.new_debs()}},
-                                {"Groups" : {"New" : que.new_groups()}},
-                                {"Shadow" : {"New" : que.new_shadow()}},
-                                {"Users" : {"New" : que.new_users()}}], indent=4, sort_keys=True)
+    new_packages =  json.dumps([{"Debs" : {"New" : que_records.new_debs()}},
+                                {"Groups" : {"New" : que_records.new_groups()}},
+                                {"Shadow" : {"New" : que_records.new_shadow()}},
+                                {"Users" : {"New" : que_records.new_users()}}], indent=4, sort_keys=True)
 
     with io.open(json_file, 'w', encoding='utf-8') as data:
         data.write(unicode(new_packages))

--- a/savant/app/results.py
+++ b/savant/app/results.py
@@ -32,7 +32,7 @@ def compare():
                                 {"Shadow" : {"New" : que_compare.new_shadow()}},
                                 {"Users" : {"New" : que_compare.new_users()}}], indent=4, sort_keys=True)
 
-    with io.open(json_file, 'w', encoding='utf-8') as data:
+    with io.open("app/" + json_file, 'w', encoding='utf-8') as data:
         data.write(unicode(new_packages))
 
     return new_packages

--- a/savant/app/results.py
+++ b/savant/app/results.py
@@ -23,15 +23,15 @@ def compare():
     filenames = request.files.getlist('files[]')
 
     get_scanned.get_items(filenames)
-    que_records = query.Query()
-    que_records.record_flavors()
+    que_compare = query.Query()
+    que_compare.record_flavors()
 
     json_file = "Comparison-" + now.strftime("%Y-%m-%d_%H:%M") + ".json"
 
-    new_packages =  json.dumps([{"Debs" : {"New" : que_records.new_debs()}},
-                                {"Groups" : {"New" : que_records.new_groups()}},
-                                {"Shadow" : {"New" : que_records.new_shadow()}},
-                                {"Users" : {"New" : que_records.new_users()}}], indent=4, sort_keys=True)
+    new_packages =  json.dumps([{"Debs" : {"New" : que_compare.new_debs()}},
+                                {"Groups" : {"New" : que_compare.new_groups()}},
+                                {"Shadow" : {"New" : que_compare.new_shadow()}},
+                                {"Users" : {"New" : que_compare.new_users()}}], indent=4, sort_keys=True)
 
     with io.open(json_file, 'w', encoding='utf-8') as data:
         data.write(unicode(new_packages))
@@ -40,7 +40,8 @@ def compare():
 
 @app.route('/doveps/api/action/create/<json_file>/<name>/<resource>/<action>', methods=['GET'])
 def create_action(json_file, name, resource, action):
-    query.record_knowledge(json_file, name, resource, action)
+    que_records = query.Query()
+    que_records.record_knowledge(json_file, name, resource, action)
      
     return jsonify({"Status" : "OK", "Message" : "Linked"})
 

--- a/savant/app/results.py
+++ b/savant/app/results.py
@@ -4,8 +4,8 @@ from app import app
 from app import get_scanned, query
 import io, json, timeit, logging, datetime, psycopg2
 
-# spcalls = SPcalls()
 now = datetime.datetime.now()
+path = str(os.getcwd()).split("/mono", 1)[0]
 
 @app.route('/doveps/api/flavor/create/', methods=['POST'])
 def create_flavors():
@@ -32,7 +32,7 @@ def compare():
                                 {"Shadow" : {"New" : que_compare.new_shadow()}},
                                 {"Users" : {"New" : que_compare.new_users()}}], indent=4, sort_keys=True)
 
-    with io.open("app/" + json_file, 'w', encoding='utf-8') as data:
+    with io.open(path + "/mono/savant/app/" + json_file, 'w', encoding='utf-8') as data:
         data.write(unicode(new_packages))
 
     return new_packages

--- a/savant/app/results.py
+++ b/savant/app/results.py
@@ -2,7 +2,6 @@ from flask import Flask, jsonify, request
 import sys, os
 from app import app
 from app import get_scanned, query
-from app.base_path import get_path
 import io, json, timeit, logging, datetime, psycopg2
 
 # spcalls = SPcalls()

--- a/savant/app/results.py
+++ b/savant/app/results.py
@@ -12,7 +12,9 @@ now = datetime.datetime.now()
 def create_flavors():
     filenames = request.files.getlist('files[]')
     get_scanned.get_items(filenames)
-    query.record_flavors()
+    # query.record_flavors()
+    que = query.Query()
+    que.record_flavors()
 
     return jsonify({"Status" : "OK", "Message" : "Saved"})
 
@@ -21,14 +23,15 @@ def compare():
     filenames = request.files.getlist('files[]')
 
     get_scanned.get_items(filenames)
-    query.record_flavors()
+    que = query.Query()
+    que.record_flavors()
 
     json_file = "Comparison-" + now.strftime("%Y-%m-%d_%H:%M") + ".json"
 
-    new_packages =  json.dumps([{"Debs" : {"New" : query.new_debs()}},
-                                {"Groups" : {"New" : query.new_groups()}},
-                                {"Shadow" : {"New" : query.new_shadow()}},
-                                {"Users" : {"New" : query.new_users()}}], indent=4, sort_keys=True)
+    new_packages =  json.dumps([{"Debs" : {"New" : que.new_debs()}},
+                                {"Groups" : {"New" : que.new_groups()}},
+                                {"Shadow" : {"New" : que.new_shadow()}},
+                                {"Users" : {"New" : que.new_users()}}], indent=4, sort_keys=True)
 
     with io.open(json_file, 'w', encoding='utf-8') as data:
         data.write(unicode(new_packages))

--- a/savant/tests/test_basic.py
+++ b/savant/tests/test_basic.py
@@ -6,8 +6,9 @@ from app.results import create_flavors, compare
 from app import query
  
 class TestDoveps(unittest.TestCase):
-    query.execute_sql("tables.sql")
-    query.execute_sql("functions.sql")
+    que_test = query.Query()
+    que_test.execute_sql("tables.sql")
+    que_test.execute_sql("functions.sql")
 
     def test_acreate_flavor(self):
         path = str(os.getcwd()).split("/mono", 1)[0]

--- a/savant/tests/test_basic.py
+++ b/savant/tests/test_basic.py
@@ -6,9 +6,6 @@ from app.results import create_flavors, compare
 from app import query
  
 class TestDoveps(unittest.TestCase):
-    que_test = query.Query()
-    que_test.execute_sql("tables.sql")
-    que_test.execute_sql("functions.sql")
 
     def test_acreate_flavor(self):
         path = str(os.getcwd()).split("/mono", 1)[0]


### PR DESCRIPTION
Was able to remove set_engine_name() and was able to avoid calling it every time I call a function for a set of queries.

One drawback however is: psycopg2 cursor and connections don't close. Because if I close them, we can't be able to run other queries. Unless if we create new ones. Which somehow defeats the purpose of removing set_engine_name(). What happens is that when a query is run it continues to pile up the cache since only one cursor is used. I want to find a way to be able to close a cursor after a certain time it's not used or maybe only after a certain time and then create a new cursor with the same variables. haven't found anything really helpful yet, though.

<!---
@huboard:{"custom_state":"archived"}
-->
